### PR TITLE
fixes the glass shiv so it now embeds on melee attack

### DIFF
--- a/modular_aeiou/code/game/objects/items/weapons/crafted_weapons_aeiou.dm
+++ b/modular_aeiou/code/game/objects/items/weapons/crafted_weapons_aeiou.dm
@@ -4,8 +4,9 @@
 	desc = "A poorly crafted shiv."
 	icon = 'modular_aeiou/icons/obj/weapons_aeiou.dmi'
 	icon_state = "glass_shiv"
-	force = 7 //Small but not nothing
+	force = 12 //Small but not nothing // EDIT: Adjusted damage to account for embed_chance formula
 	embed_chance = 100 //this should go in everytime
+	sharp = 1 // now it should actually embed every time
 	throwforce = 2
 	w_class = ITEMSIZE_SMALL
 	attack_verb = list("attacked", "stabbed", "poked", "stabbed", "pierced")


### PR DESCRIPTION
I noticed the glass shiv wasn't embedding at all when I was testing it out, even though its embed_chance was set to 100. Poked my nose around and realized there's a formula involved that was apparently causing an overflow. With a bit more damage and giving it sharpness, it should now have a base 100% chance to embed on attack as originally intended.