### PR TITLE
Fixes UI window sizes, auto-hiss persistence, and singularity messages.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -822,7 +822,7 @@
 	if(panel_open)
 		wires.Interact(user)
 
-	user << browse(dat, "window=suit_cycler")
+	user << browse(dat, "window=suit_cycler;size=400x435") //AEIOU-Station Edit: Opened too small when size was omitted.
 	onclose(user, "suit_cycler")
 	return
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -90,7 +90,7 @@
 	dat += "</table><hr>"
 	dat += "Currently displaying [show_all_ores ? "all ore types" : "only available ore types"]. <A href='?src=\ref[src];toggle_ores=1'>\[[show_all_ores ? "show less" : "show more"]\]</a></br>"
 	dat += "The ore processor is currently <A href='?src=\ref[src];toggle_power=1'>[(machine.active ? "<font color='green'>processing</font>" : "<font color='red'>disabled</font>")]</a>."
-	user << browse(dat, "window=processor_console;size=400x500")
+	user << browse(dat, "window=processor_console;size=400x560") //AEIOU-Station Edit: 400x500 was too small for all ores view.
 	onclose(user, "processor_console")
 	return
 

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -10,14 +10,14 @@
 	return message // no autohiss at this level
 
 /mob/living/carbon/human/handle_autohiss(message, datum/language/L)
-	if(!client || client.autohiss_mode == AUTOHISS_OFF) // no need to process if there's no client or they have autohiss off
+	if(!client || autohiss_mode == AUTOHISS_OFF) // no need to process if there's no client or they have autohiss off //AEIOU-Station Edit: autohiss_mode is now a human mob var.
 		return message
-	return species.handle_autohiss(message, L, client.autohiss_mode)
+	return species.handle_autohiss(message, L, autohiss_mode) //AEIOU-Station Edit: autohiss_mode is now a human mob var.
 
-/client
+/mob/living/carbon/human //AEIOU-Station Edit: Instead of /client - Fixed autohiss being lost on disconnect.
 	var/autohiss_mode = AUTOHISS_OFF
 
-/client/verb/toggle_autohiss()
+/mob/living/carbon/human/verb/toggle_autohiss() //AEIOU-Station Edit: Instead of /client - Autohiss fix.
 	set name = "Toggle Auto-Hiss"
 	set desc = "Toggle automatic hissing as Unathi and r-rolling as Taj"
 	set category = "OOC"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -68,7 +68,7 @@
 
 	output += "</div>"
 
-	panel = new(src, "Welcome","Welcome", 210, 280, src)
+	panel = new(src, "Welcome","Welcome", 210, 285, src) //AEIOU-Station Edit: 210x280 was too small for post-roundstart menu.
 	panel.set_window_options("can_close=0")
 	panel.set_content(output)
 	panel.open()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_BOILERPLATE(all_singularities, /obj/singularity)
 			allowed_size = STAGE_SUPER
 
 	if (current_size != allowed_size && current_size != STAGE_SUPER)
-		expand(null, current_size > allowed_size)
+		expand(null, current_size < allowed_size) //AEIOU-Station Edit: Fixed singulo grow/shrink messages being backwards.
 	return 1
 
 /obj/singularity/proc/eat()


### PR DESCRIPTION
A bundle of fixes for AEIOU. Some more details on the fixes:
* Resizes the lobby menu, suit cycler UI, and ore processor UI so you're not left with a window that's slightly too small with an unnecessary scrollbar. It was also annoying having to resize each time to use the machines quickly with the bottommost buttons.
* Auto-hiss no longer resets each time you lose connection. It's attached to the mob now instead of the client and should persist as long as the mob is in existence.
* Singularity grow/shrink messages between stages were backwards. A simple adjustment has been made to fix this. (Note: As it's currently coded, there is no way to invoke the proper message when the singularity drops from Super to Five. But that's a different issue and not the aim of this fix. You won't see that happen anyway.)

As always, I'm open to discussion if you have suggestions or think I didn't do something quite right.