### PR TITLE
Fixes suit cyclers ignoring helmets in suits and replaces bloated code.

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -987,184 +987,27 @@
 		if(helmet) helmet.refit_for_species(target_species)
 		if(suit) suit.refit_for_species(target_species)
 
-	switch(target_department)
-		if("Engineering")
-			if(helmet)
-				helmet.name = "engineering voidsuit helmet"
-				helmet.icon_state = "rig0-engineering"
-				helmet.item_state = "rig0-engineering"
-			if(suit)
-				suit.name = "engineering voidsuit"
-				suit.icon_state = "rig-engineering"
-				suit.item_state = "rig-engineering"
-				suit.item_state_slots[slot_r_hand_str] = "eng_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "eng_voidsuit"
-		if("Mining")
-			if(helmet)
-				helmet.name = "mining voidsuit helmet"
-				helmet.icon_state = "rig0-mining"
-				helmet.item_state = "rig0-mining"
-			if(suit)
-				suit.name = "mining voidsuit"
-				suit.icon_state = "rig-mining"
-				suit.item_state = "rig-mining"
-				suit.item_state_slots[slot_r_hand_str] = "mining_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "mining_voidsuit"
-		if("Medical")
-			if(helmet)
-				helmet.name = "medical voidsuit helmet"
-				helmet.icon_state = "rig0-medical"
-				helmet.item_state = "rig0-medical"
-			if(suit)
-				suit.name = "medical voidsuit"
-				suit.icon_state = "rig-medical"
-				suit.item_state = "rig-medical"
-				suit.item_state_slots[slot_r_hand_str] = "medical_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "medical_voidsuit"
-		if("Security")
-			if(helmet)
-				helmet.name = "security voidsuit helmet"
-				helmet.icon_state = "rig0-sec"
-				helmet.item_state = "rig0-sec"
-			if(suit)
-				suit.name = "security voidsuit"
-				suit.icon_state = "rig-sec"
-				suit.item_state = "rig-sec"
-				suit.item_state_slots[slot_r_hand_str] = "sec_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "sec_voidsuit"
-		if("Crowd Control")
-			if(helmet)
-				helmet.name = "crowd control voidsuit helmet"
-				helmet.icon_state = "rig0-sec_riot"
-				helmet.item_state = "rig0-sec_riot"
-			if(suit)
-				suit.name = "crowd control voidsuit"
-				suit.icon_state = "rig-sec_riot"
-				suit.item_state = "rig-sec_riot"
-				suit.item_state_slots[slot_r_hand_str] = "sec_voidsuit_riot"
-				suit.item_state_slots[slot_l_hand_str] = "sec_voidsuit_riot"
-		if("Atmos")
-			if(helmet)
-				helmet.name = "atmospherics voidsuit helmet"
-				helmet.icon_state = "rig0-atmos"
-				helmet.item_state = "rig0-atmos"
-			if(suit)
-				suit.name = "atmospherics voidsuit"
-				suit.icon_state = "rig-atmos"
-				suit.item_state = "rig-atmos"
-				suit.item_state_slots[slot_r_hand_str] = "atmos_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "atmos_voidsuit"
-		if("HAZMAT")
-			if(helmet)
-				helmet.name = "HAZMAT voidsuit helmet"
-				helmet.icon_state = "rig0-engineering_rad"
-				helmet.item_state = "rig0-engineering_rad"
-			if(suit)
-				suit.name = "HAZMAT voidsuit"
-				suit.icon_state = "rig-engineering_rad"
-				suit.item_state = "rig-engineering_rad"
-				suit.item_state_slots[slot_r_hand_str] = "eng_voidsuit_rad"
-				suit.item_state_slots[slot_l_hand_str] = "eng_voidsuit_rad"
-		if("Construction")
-			if(helmet)
-				helmet.name = "Construction voidsuit helmet"
-				helmet.icon_state = "rig0-engineering_con"
-				helmet.item_state = "rig0-engineering_con"
-			if(suit)
-				suit.name = "Construction voidsuit"
-				suit.icon_state = "rig-engineering_con"
-				suit.item_state = "rig-engineering_con"
-				suit.item_state_slots[slot_r_hand_str] = "eng_voidsuit_con"
-				suit.item_state_slots[slot_l_hand_str] = "eng_voidsuit_con"
-		if("Biohazard")
-			if(helmet)
-				helmet.name = "Biohazard voidsuit helmet"
-				helmet.icon_state = "rig0-medical_bio"
-				helmet.item_state = "rig0-medical_bio"
-			if(suit)
-				suit.name = "Biohazard voidsuit"
-				suit.icon_state = "rig-medical_bio"
-				suit.item_state = "rig-medical_bio"
-				suit.item_state_slots[slot_r_hand_str] = "medical_voidsuit_bio"
-				suit.item_state_slots[slot_l_hand_str] = "medical_voidsuit_bio"
-		if("Emergency Medical Response")
-			if(helmet)
-				helmet.name = "emergency medical response voidsuit helmet"
-				helmet.icon_state = "rig0-medical_emt"
-				helmet.item_state = "rig0-medical_emt"
-			if(suit)
-				suit.name = "emergency medical response voidsuit"
-				suit.icon_state = "rig-medical_emt"
-				suit.item_state = "rig-medical_emt"
-				suit.item_state_slots[slot_r_hand_str] = "medical_voidsuit_emt"
-				suit.item_state_slots[slot_l_hand_str] = "medical_voidsuit_emt"
-		if("^%###^%$" || "Mercenary")
-			if(helmet)
-				helmet.name = "blood-red voidsuit helmet"
-				helmet.icon_state = "rig0-syndie"
-				helmet.item_state = "rig0-syndie"
-			if(suit)
-				suit.name = "blood-red voidsuit"
-				suit.item_state = "rig-syndie"
-				suit.icon_state = "rig-syndie"
-				suit.item_state_slots[slot_r_hand_str] = "syndie_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "syndie_voidsuit"
-		if("Charring")
-			if(helmet)
-				helmet.name = "soot-covered voidsuit helmet"
-				helmet.icon_state = "rig0-firebug"
-				helmet.item_state = "rig0-firebug"
-			if(suit)
-				suit.name = "soot-covered voidsuit"
-				suit.item_state = "rig-firebug"
-				suit.icon_state = "rig-firebug"
-				suit.item_state_slots[slot_r_hand_str] = "rig-firebug"
-				suit.item_state_slots[slot_l_hand_str] = "rig-firebug"
-		if("Exploration")
-			if(helmet)
-				helmet.name = "exploration voidsuit helmet"
-				helmet.icon_state = "helm_explorer"
-				helmet.item_state = "helm_explorer"
-			if(suit)
-				suit.name = "exploration voidsuit"
-				suit.icon_state = "void_explorer"
-				suit.item_state = "void_explorer"
-				suit.item_state_slots[slot_r_hand_str] = "wiz_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "wiz_voidsuit"
-		if("Old Exploration")
-			if(helmet)
-				helmet.name = "exploration voidsuit helmet"
-				helmet.icon_state = "helm_explorer2"
-				helmet.item_state = "helm_explorer2"
-			if(suit)
-				suit.name = "exploration voidsuit"
-				suit.icon_state = "void_explorer2"
-				suit.item_state = "void_explorer2"
-				suit.item_state_slots[slot_r_hand_str] = "wiz_voidsuit"
-				suit.item_state_slots[slot_l_hand_str] = "wiz_voidsuit"
-		if("Pilot")
-			if(helmet)
-				helmet.name = "pilot voidsuit helmet"
-				helmet.icon_state = "rig0_pilot"
-				helmet.item_state = "pilot_helm"
-			if(suit)
-				suit.name = "pilot voidsuit"
-				suit.icon_state = "rig-pilot"
-				suit.item_state = "rig-pilot"
-				suit.item_state_slots[slot_r_hand_str] = "sec_voidsuitTG"
-				suit.item_state_slots[slot_l_hand_str] = "sec_voidsuitTG"
-		if("Pilot Blue")
-			if(helmet)
-				helmet.name = "pilot voidsuit helmet"
-				helmet.icon_state = "rig0_pilot2"
-				helmet.item_state = "pilot_helm2"
-			if(suit)
-				suit.name = "pilot voidsuit"
-				suit.icon_state = "rig-pilot2"
-				suit.item_state = "rig-pilot2"
-				suit.item_state_slots[slot_r_hand_str] = "sec_voidsuitTG"
-				suit.item_state_slots[slot_l_hand_str] = "sec_voidsuitTG"
+	//AEIOU-Station Edit: Say hello to a less bloated way to do this. Lookup tables are in suit_storage_unit_vr.dm.
+	if(target_department)
+		if(helmet)
+			helmet.name = paintjobs_helmet[target_department][1]
+			helmet.icon_state = paintjobs_helmet[target_department][2]
+			helmet.item_state = paintjobs_helmet[target_department][3]
+		if(suit)
+			suit.name = paintjobs_suit[target_department][1]
+			suit.icon_state = paintjobs_suit[target_department][2]
+			suit.item_state = paintjobs_suit[target_department][3]
+			suit.item_state_slots[slot_r_hand_str] = paintjobs_suit[target_department][4]
+			suit.item_state_slots[slot_l_hand_str] = paintjobs_suit[target_department][4]
+			if(suit.helmet) // Another facet of this edit. Helmets inside suits are no longer ignored.
+				suit.helmet.name = paintjobs_helmet[target_department][1]
+				suit.helmet.icon_state = paintjobs_helmet[target_department][2]
+				suit.helmet.item_state = paintjobs_helmet[target_department][3]
 
 
-	if(helmet) helmet.name = "refitted [helmet.name]"
-	if(suit) suit.name = "refitted [suit.name]"
+	if(target_species != SPECIES_HUMAN) // The original model isn't "refitted"
+		if(helmet) helmet.name = "refitted [helmet.name]"
+		if(suit)
+			suit.name = "refitted [suit.name]"
+			if(suit.helmet) suit.helmet.name = "refitted [suit.helmet.name]"
+	//AEIOU-Station Edit End

--- a/code/game/machinery/suit_storage_unit_vr.dm
+++ b/code/game/machinery/suit_storage_unit_vr.dm
@@ -17,6 +17,46 @@
 		SPECIES_ZORREN_FLAT,
 		SPECIES_ZORREN_HIGH
 	)
+	//AEIOU-Station Add: Lookup tables for apply_paintjob edit.
+	var/paintjobs_helmet = list(
+		"Engineering" = list("engineering voidsuit helmet", "rig0-engineering", "rig0-engineering"),
+		"Mining" = list("mining voidsuit helmet", "rig0-mining", "rig0-mining"),
+		"Medical" = list("medical voidsuit helmet", "rig0-medical", "rig0-medical"),
+		"Security" = list("security voidsuit helmet", "rig0-sec", "rig0-sec"),
+		"Crowd Control" = list("crowd control voidsuit helmet", "rig0-sec_riot", "rig0-sec_riot"),
+		"Atmos" = list("atmospherics voidsuit helmet", "rig0-atmos", "rig0-atmos"),
+		"HAZMAT" = list("HAZMAT voidsuit helmet", "rig0-engineering_rad", "rig0-engineering_rad"),
+		"Construction" = list("construction voidsuit helmet", "rig0-engineering_con", "rig0-engineering_con"),
+		"Biohazard" = list("biohazard voidsuit helmet", "rig0-medical_bio", "rig0-medical_bio"),
+		"Emergency Medical Response" = list("emergency medical response voidsuit helmet", "rig0-medical_emt", "rig0-medical_emt"),
+		"^%###^%$" = list("blood-red voidsuit helmet", "rig0-syndie", "rig0-syndie"),
+		"Mercenary" = list("blood-red voidsuit helmet", "rig0-syndie", "rig0-syndie"),
+		"Charring" = list("soot-covered voidsuit helmet", "rig0-firebug", "rig0-firebug"),
+		"Exploration" = list("exploration voidsuit helmet", "helm_explorer", "helm_explorer"),
+		"Old Exploration" = list("exploration voidsuit helmet", "helm_explorer2", "helm_explorer2"),
+		"Pilot" = list("pilot voidsuit helmet", "rig0_pilot", "pilot_helm"),
+		"Pilot Blue" = list("pilot voidsuit helmet", "rig0_pilot2", "pilot_helm2")
+	)
+	var/paintjobs_suit = list(
+		"Engineering" = list("engineering voidsuit", "rig-engineering", "rig-engineering", "eng_voidsuit"),
+		"Mining" = list("mining voidsuit", "rig-mining", "rig-mining", "mining_voidsuit"),
+		"Medical" = list("medical voidsuit", "rig-medical", "rig-medical", "medical_voidsuit"),
+		"Security" = list("security voidsuit", "rig-sec", "rig-sec", "sec_voidsuit"),
+		"Crowd Control" = list("crowd control voidsuit", "rig-sec_riot", "rig-sec_riot", "sec_voidsuit_riot"),
+		"Atmos" = list("atmospherics voidsuit", "rig-atmos", "rig-atmos", "atmos_voidsuit"),
+		"HAZMAT" = list("HAZMAT voidsuit", "rig-engineering_rad", "rig-engineering_rad", "eng_voidsuit_rad"),
+		"Construction" = list("construction voidsuit", "rig-engineering_con", "rig-engineering_con", "eng_voidsuit_con"),
+		"Biohazard" = list("biohazard voidsuit", "rig-medical_bio", "rig-medical_bio", "medical_voidsuit_bio"),
+		"Emergency Medical Response" = list("emergency medical response voidsuit", "rig-medical_emt", "rig-medical_emt", "medical_voidsuit_emt"),
+		"^%###^%$" = list("blood-red voidsuit", "rig-syndie", "rig-syndie", "syndie_voidsuit"),
+		"Mercenary" = list("blood-red voidsuit", "rig-syndie", "rig-syndie", "syndie_voidsuit"),
+		"Charring" = list("soot-covered voidsuit", "rig-firebug", "rig-firebug", "rig-firebug"),
+		"Exploration" = list("exploration voidsuit", "void_explorer", "void_explorer", "wiz_voidsuit"),
+		"Old Exploration" = list("exploration voidsuit", "void_explorer2", "void_explorer2", "wiz_voidsuit"),
+		"Pilot" = list("pilot voidsuit", "rig-pilot", "rig-pilot", "sec_voidsuitTG"),
+		"Pilot Blue" = list("pilot voidsuit", "rig-pilot2", "rig-pilot2", "sec_voidsuitTG", "sec_voidsuitTG")
+	)
+	//AEIOU-Station Add End
 
 // Old Exploration is too WIP to use right now
 /obj/machinery/suit_cycler/exploration


### PR DESCRIPTION
A resubmission of the change I made last year, updated and code guidelines compliant.

The fix was originally just to include helmets inside suits, but I ended up rehauling a section of the proc to remove a lot of unnecessarily redundant lines of code. I didn't want to end up writing the same lines of code 16 times.

I used find/replace with regex on the switch structure to build the lookup tables around the names, to ensure accuracy and completeness.

As always, I'm open to discussion.