### PR TITLE
making friends with umbrellas and phaseguns

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -606,12 +606,12 @@
 /mob/living/simple_animal/bullet_act(var/obj/item/projectile/Proj)
 	ai_log("bullet_act() I was shot by: [Proj.firer]",2)
 
-	/* VOREStation Edit - Ace doesn't like bonus SA damage.
+	//VOREStation Edit - Ace doesn't like bonus SA damage. //AEIOU Edit -- Why do you even have phase weapons if you're going to make them useless?
 	//Projectiles with bonus SA damage
 	if(!Proj.nodamage)
 		if(!Proj.SA_vulnerability || Proj.SA_vulnerability == intelligence_level)
 			Proj.damage += Proj.SA_bonus_damage
-	*/ // VOREStation Edit End
+	// VOREStation Edit End
 	. = ..()
 
 	if(Proj.firer)

--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -332,13 +332,13 @@ var/datum/planet/sif/planet_sif = null
 				if(istype(L.get_active_hand(), /obj/item/weapon/melee/umbrella))
 					var/obj/item/weapon/melee/umbrella/U = L.get_active_hand()
 					if(U.open)
-						to_chat(L, "<span class='danger'>You struggle to keep hold of your umbrella!</span>")
-						L.Stun(20)	// This is not nearly as long as it seems
+						L.visible_message("<span class='danger'>[L] struggles to keep hold of their umbrella!</span>","<span class='danger'>You struggle to keep hold of your umbrella!</span>") //AEIOU Edit -- Adds a message visible to people who can see you
+						L.Stun(2)	// This is not nearly as long as it seems //AEIOU Edit -- I don't know what happened between the time this was added and now, but 20 seconds is way too long
 						playsound(L, 'sound/effects/rustle1.ogg', 100, 1)	// Closest sound I've got to "Umbrella in the wind"
 				else if(istype(L.get_inactive_hand(), /obj/item/weapon/melee/umbrella))
 					var/obj/item/weapon/melee/umbrella/U = L.get_inactive_hand()
 					if(U.open)
-						to_chat(L, "<span class='danger'>A gust of wind yanks the umbrella from your hand!</span>")
+						L.visible_message("<span class='danger'>[L]'s umbrella is yanked from their hand by the wind!</span>","<span class='danger'>A gust of wind yanks the umbrella from your hand!</span>") //AEIOU Edit -- Same as the other message
 						playsound(L, 'sound/effects/rustle1.ogg', 100, 1)
 						L.drop_from_inventory(U)
 						U.toggle_umbrella()
@@ -417,7 +417,7 @@ var/datum/planet/sif/planet_sif = null
 				if(show_message)
 					to_chat(H, "<span class='notice'>Hail patters onto your umbrella.</span>")
 				continue
-		
+
 			var/target_zone = pick(BP_ALL)
 			var/amount_blocked = H.run_armor_check(target_zone, "melee")
 			var/amount_soaked = H.get_armor_soak(target_zone, "melee")


### PR DESCRIPTION
This is a partial followup to #147 from when I observed how long you are stunned if you're holding an umbrella in a storm, but also to fix #134 where phase weapons are useless because of a commented block of code. Thank you @EvilJackCarver for figuring that out the first time and also for reminding me about it recently.

Phase weapons of all varieties (and the BB gun, for that matter) should now do their intended damage to mobs. Hurray for explorers and anyone else that needs to protect themselves from hostile fauna like ~~Ian~~ giant spiders and slightly angrier giant spiders and **really pissed off** giant spiders.

For whatever reason, the stun dealt to someone holding an umbrella is 20 seconds long. I have no idea why it is that long, I assume it has something to do with a conversion from deciseconds that simply doesn't happen in this particular dm file. This PR reduces that to two seconds, which is far more reasonable and allows for some wiggle room for someone who feels stubborn enough to press forward and keep themselves dry. In addition, anyone that is near you will now be aware that someone with an umbrella is having difficulty, where you previously had to explain why you weren't moving any more. For consitency's sake, a similar message has been added for when an umbrella is ripped from your hand by the wind so that another player doesn't think you just threw your umbrella into their face for some reason.