### PR TITLE
Fixes #132 and adds unbuckle message to vehicles.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -862,6 +862,12 @@ default behaviour is:
 	if(istype(src.loc, /obj/item/weapon/holder))
 		escape_inventory(src.loc)
 		return
+	//AEIOU-Station Add: To dismount vehicles, unbuckling isn't enough.
+	if(istype(buckled, /obj/vehicle))
+		var/obj/vehicle/V = buckled
+		V.unload(src)
+		return TRUE
+	//AEIOU-Station Add End
 
 	//unbuckling yourself
 	if(buckled)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -397,7 +397,12 @@
 	load.layer = initial(load.layer)
 
 	if(ismob(load))
-		unbuckle_mob(load)
+		//AEIOU-Station Edit: Show unbuckle message if unbuckled by a mob (including self).
+		if(user)
+			user_unbuckle_mob(load, user)
+		else
+			unbuckle_mob(load)
+		//AEIOU-Station Edit End
 
 	load = null
 


### PR DESCRIPTION
The issue was caused by the fact that after the resist verb unbuckled you, you were still loaded to the tug. Teleporting was caused by the unload proc assuming you were still on the tug and force-moving you to a tile according to its decision process.

I also noticed that buckling to the tug displayed a message, while unbuckling didn't. I modified the code to call the proper proc that would display an unbuckle message.