### PR TITLE
Fixes a typo, now including the inactive hand in disarms.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -291,7 +291,7 @@
 				w_uniform.add_fingerprint(M)
 			var/obj/item/organ/external/affecting = get_organ(ran_zone(M.zone_sel.selecting))
 
-			var/list/holding = list(get_active_hand() = 40, get_inactive_hand = 20)
+			var/list/holding = list(get_active_hand() = 40, get_inactive_hand() = 20)
 
 			//See if they have any guns that might go off
 			for(var/obj/item/weapon/gun/W in holding)


### PR DESCRIPTION
It appears the inactive hand immunity from disarms was merely a bug that's been around since April 2015. This PR fixes a typo that was present in the original edit to the code. Sorry in advance to everyone who's gotten used to exploiting the off-hand immunity.