### PR TITLE
Replaces suit cycler in mining outpost with mining subtype.

### DIFF
--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -387,7 +387,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
-/obj/machinery/suit_cycler,
+/obj/machinery/suit_cycler/mining,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/mining_main/storage)
 "bd" = (


### PR DESCRIPTION
The access problem with the suit cycler in the mining outpost originated from the fact that it was the generic type that contains all departments and can only be opened by the CD. After this change the cycler in the outpost will be the mining cycler, now able to be opened by miners.

No longer do miners who require a suit need to rely solely on the station-side cycler to refit their suits.