### PR TITLE
Fixes three river names in outpost and wilderness maps.

### DIFF
--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -108,13 +108,13 @@
 	icon_state = "bluenew"
 
 /area/surface/outside/river/faxalven
-	name = "Fax√§lven River"
+	name = "Fax‰lven River"
 
 /area/surface/outside/river/indalsalven
-	name = "Indals√§lven River"
+	name = "Indals‰lven River"
 
 /area/surface/outside/river/svartan
-	name = "Svart√•n River"
+	name = "SvartÂn River"
 
 /area/surface/outside/lake/romsele
 	name = "Romsele Lake"


### PR DESCRIPTION
The names of the Faxälven and Indalsälven Rivers on the outpost level and the Svartån River in the wilderness are stored in UTF-8 format, but the game uses ISO and causes them to render incorrectly (e.g. "FaxÃ¤lven River"). I fixed the names, so they should render correctly now.

Note: GitHub appears to parse both UTF-8 and ISO, so it doesn't look like there's any change.