### PR TITLE
Fixed final vote message to say "ONLY" only if it's the only one.

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -21,7 +21,7 @@ datum/controller/transfer_controller/proc/process()
 	//VOREStation Edit START
 	if (round_duration_in_ticks >= shift_last_vote - 2 MINUTES)
 		shift_last_vote = 999999999999 //Setting to a stupidly high number since it'll be not used again.
-		to_world("<b>Warning: This upcoming round-extend vote will be your ONLY extend vote. Wrap up your scenes in the next 60 minutes if the round is extended.</b>") //VOREStation Edit
+		to_world("<b>Warning: This upcoming round-extend vote will be your [NUMBER_OF_VOTE_EXTENSIONS > 1 ? "FINAL" : "ONLY"] extend vote. Wrap up your scenes in the next 60 minutes if the round is extended.</b>") //VOREStation Edit //AEIOU-Station Edit: "FINAL" or "ONLY" depending on final or only.
 	if (round_duration_in_ticks >= shift_hard_end - 1 MINUTE)
 		init_shift_change(null, 1)
 		shift_hard_end = timerbuffer + config.vote_autotransfer_interval //If shuttle somehow gets recalled, let's force it to call again next time a vote would occur.


### PR DESCRIPTION
Otherwise, it'll properly say this will be your FINAL extend vote.